### PR TITLE
Make sequelize-paper-trail work with sequelize v4.0

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -21,8 +21,8 @@ exports.init = function (sequelize, optionsArg) {
   // In case that options is being parsed as a readonly attribute.
   var options = _.cloneDeep(optionsArg);
   var defaultAttributes = {
-    documentId: 'document_id',
-    revisionId: 'revision_id'
+    documentId: 'documentId',
+    revisionId: 'revisionId'
   };
 
   // if no options are passed the function
@@ -190,7 +190,7 @@ exports.init = function (sequelize, optionsArg) {
 
       // create association
       this.hasMany(sequelize.models[options.revisionModel], {
-        foreignKey: "document_id",
+        foreignKey: options.defaultAttributes.documentId,
         constraints: false,
         scope: {
           model: this.name
@@ -295,7 +295,7 @@ exports.init = function (sequelize, optionsArg) {
       // Build revision
       var revision = Revision.build({
         model: this.name,
-        document_id: instance.id,
+        documentId: instance.id,
         document: JSON.stringify(currentVersion),
         user_id: ns.get(options.continuationKey)
       });

--- a/lib/index.js
+++ b/lib/index.js
@@ -297,7 +297,7 @@ exports.init = function (sequelize, optionsArg) {
         model: this.name,
         documentId: instance.id,
         document: JSON.stringify(currentVersion),
-        user_id: ns.get(options.continuationKey)
+        userId: ns.get(options.continuationKey) || opt.userId
       });
 
       revision[options.revisionAttribute] = instance.get(options.revisionAttribute);
@@ -438,11 +438,7 @@ exports.init = function (sequelize, optionsArg) {
 
 
       if (options.userModel) {
-        Revision.belongsTo(sequelize.model(options.userModel), {
-          foreignKey: "user_id",
-          constraints: true,
-          as: "userId"
-        });
+        Revision.belongsTo(sequelize.model(options.userModel));
       }
       return Revision;
     }

--- a/lib/index.js
+++ b/lib/index.js
@@ -148,7 +148,7 @@ exports.init = function (sequelize, optionsArg) {
 
   // Extend model prototype with "enableAuditTrails" function
   // Call model.enableAuditTrails() to enable revisions for model
-  _.extend(sequelize.Model.prototype, {
+  _.extend(sequelize.Model, {
     hasPaperTrail: function hasPaperTrail() {
       if (debug) {
         log('Enabling paper trail on', this.name);
@@ -294,7 +294,7 @@ exports.init = function (sequelize, optionsArg) {
 
       // Build revision
       var revision = Revision.build({
-        model: opt.model.name,
+        model: this.name,
         document_id: instance.id,
         document: JSON.stringify(currentVersion),
         user_id: ns.get(options.continuationKey)


### PR DESCRIPTION
Sequelize v4.0 had made some breaking changes which caused sequelize-paper-trail stop working.
I have made below changes, mainly to make it work with sequqlize v4.0 and to use it in my project.

1. Attach hasPaperTrail() method to the new sequelize Model class.
2. Change default param names to userId and documentId to confirm with the documentation.
3. Track user who has created the revision by accepting userId as a param in options.

Please provide your valuable comments and suggestions.