### PR TITLE
package.json: Removes upper version limit on node & npm engines

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
   },
   "main": "lib/index.js",
   "engines": {
-    "node": ">=5.0.0 <6",
-    "npm": ">=3.3 <4"
+    "node": ">=5.0.0",
+    "npm": ">=3.3"
   },
   "scripts": {
     "test": "mocha test/* --reporter dot --compilers js:babel-register --require ./test/helper.js --recursive",


### PR DESCRIPTION
The maximum version constrain set on the node & npm engines makes the package unusable with the recent node versions. This PR removes that upper limit.  