### PR TITLE
Return hasMany association from hasPaperTrail to capture assocaition

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,8 @@ Then for each model that you want to keep a paper trail you simply add:
 Model.hasPaperTrail();
 ```
 
+`hasPaperTrail` returns the `hasMany` association to the `revisionModel` so you can keep track of the association for reference later.
+
 ### Example
 
 ```javascript
@@ -83,7 +85,7 @@ var User = sequelize.define('User', {
   birthday: Sequelize.DATE
 });
 
-User.hasPaperTrail();
+User.Revisions = User.hasPaperTrail();
 ```
 
 ## User Tracking

--- a/lib/index.js
+++ b/lib/index.js
@@ -146,8 +146,8 @@ exports.init = function (sequelize, optionsArg) {
   // afterBulkDestroy(instances, options, fn)
   // afterBulkUpdate(instances, options, fn)
 
-  // Extend model prototype with "enableAuditTrails" function
-  // Call model.enableAuditTrails() to enable revisions for model
+  // Extend model prototype with "hasPaperTrail" function
+  // Call model.hasPaperTrail() to enable revisions for model
   _.extend(sequelize.Model, {
     hasPaperTrail: function hasPaperTrail() {
       if (debug) {
@@ -189,15 +189,13 @@ exports.init = function (sequelize, optionsArg) {
       this.addHook("afterUpdate", afterHook);
 
       // create association
-      this.hasMany(sequelize.models[options.revisionModel], {
+      return this.hasMany(sequelize.models[options.revisionModel], {
         foreignKey: options.defaultAttributes.documentId,
         constraints: false,
         scope: {
           model: this.name
         }
       });
-
-      return this;
     }
   });
 


### PR DESCRIPTION
In my app, I setup associations as properties on the model so I can reference them later in `includes` or other places in the Sequelize API.

I figured the `hasPaperTrail` method is not explicitly designed for chaining, so might as well return the created association so callers can use it.