### PR TITLE
Enable cls based on options.continuationNamespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ var options = {
   userModel: 'user',
 };
 ```
-2. Pass the id of the user who is responsible for a database operation to `sequelize-paper-trail` either by sequelize options or by using [continuation-local-storage](https://www.npmjs.com/package/continuation-local-storage).
+2. Pass the id of the user who is responsible for the database operation to `sequelize-paper-trail` either by sequelize options or by using [continuation-local-storage](https://www.npmjs.com/package/continuation-local-storage).
 
 ```javascript
 Model.update({
@@ -126,7 +126,8 @@ Model.update({
 
 ```
 
-In second case, you may have to call `.run()` or `.bind()` on your cls namespace, as described in the [docs](https://www.npmjs.com/package/continuation-local-storage).
+To enable continuation-local-storage set `continuationNamespace` in initialization options.
+Additionally, you may also have to call `.run()` or `.bind()` on your cls namespace, as described in the [docs](https://www.npmjs.com/package/continuation-local-storage).
 
 ## Options
 
@@ -160,7 +161,6 @@ var options = {
   enableCompression: false,
   enableMigration: false,
   enableStrictDiff: true,
-  continuationNamespace: 'current_user_request',
   continuationKey: 'userId'
 };
 ```
@@ -183,7 +183,7 @@ var options = {
 | [enableCompression] | Boolean | false | Compresses the revision attribute in the [revisionModel] to only the diff instead of all model attributes. |
 | [enableMigration] | Boolean | false | Automatically adds the [revisionAttribute] via a migration to the models that have paper trails enabled. |
 | [enableStrictDiff] | Boolean | true | Reports integers and strings as different, e.g. `3.14` !== `'3.14'` |
-| [continuationNamespace] | String | 'current_user_request' | Name of the name space used with the continuation-local-storage module. |
+| [continuationNamespace] | String | | Name of the name space used with the continuation-local-storage module. |
 | [continuationKey] | String | 'userId' | The continuation-local-storage key that contains the user id. |
 
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -105,22 +105,21 @@ exports.init = function (sequelize, optionsArg) {
     options.enableStrictDiff = true;
   }
 
-  if (!options.continuationNamespace) {
-    options.continuationNamespace = 'current_user_request';
-  }
+  var ns;
+  if (options.continuationNamespace) {
+    ns = cls.getNamespace(options.continuationNamespace);
+    if (!ns) {
+      ns = cls.createNamespace(options.continuationNamespace);
+    }
 
-  if (!options.continuationKey) {
-    options.continuationKey = 'userId';
+    if (!options.continuationKey) {
+      options.continuationKey = 'userId';
+    }
   }
 
   if (debug) {
     log('parsed options:');
     log(options);
-  }
-
-  var ns = cls.getNamespace(options.continuationNamespace);
-  if (!ns) {
-    ns = cls.createNamespace(options.continuationNamespace);
   }
 
   // order in which sequelize processes the hooks
@@ -266,7 +265,9 @@ exports.init = function (sequelize, optionsArg) {
       log('afterHook called');
       log('instance:', instance);
       log('opt:', opt);
-      log(`CLS ${options.continuationKey}:`, ns.get(options.continuationKey));
+      if (ns) {
+        log(`CLS ${options.continuationKey}:`, ns.get(options.continuationKey));
+      }
     }
 
     if (instance.context && instance.context.delta && instance.context.delta.length > 0) {
@@ -302,7 +303,7 @@ exports.init = function (sequelize, optionsArg) {
         model: this.name,
         documentId: instance.id,
         document: JSON.stringify(currentVersion),
-        userId: ns.get(options.continuationKey) || opt[options.continuationKey]
+        userId: ns && ns.get(options.continuationKey) || opt[options.continuationKey]
       });
 
       revision[options.revisionAttribute] = instance.get(options.revisionAttribute);


### PR DESCRIPTION
Currently cls is enabled by default. However, not all applications needs that. This commit disables cls by default. Enable cls only if options.continuationNamespace is set.