### PR TITLE
Increment revisionId only if there is a delta

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -249,8 +249,9 @@ exports.init = function (sequelize, optionsArg) {
       log('revisionId', currentRevisionId);
     }
 
-    instance.set(options.revisionAttribute, (currentRevisionId || 0) + 1);
     if (delta && delta.length > 0) {
+      instance.set(options.revisionAttribute, (currentRevisionId || 0) + 1);
+
       if (!instance.context) {
         instance.context = {};
       }


### PR DESCRIPTION
Currently revisionId is incremented even if there is no change in data. This commit increments revisionId only if there is some change in data denoted by non null delta value.