### PR TITLE
Capitalised table names cause user foreign key to be "UserId" while expecting "userId"

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -392,7 +392,9 @@ exports.init = function (sequelize, optionsArg) {
         underscored: options.underscored
       });
       Revision.associate = function associate(models) {
-          Revision.belongsTo(sequelize.model(options.userModel));
+          Revision.belongsTo(sequelize.model(options.userModel), {
+            foreignKey: 'userId'
+          });
       }
 
       attributes = {
@@ -441,7 +443,9 @@ exports.init = function (sequelize, optionsArg) {
 
 
       if (options.userModel) {
-        Revision.belongsTo(sequelize.model(options.userModel));
+        Revision.belongsTo(sequelize.model(options.userModel), {
+          foreignKey: 'userId'
+        });
       }
       return Revision;
     }


### PR DESCRIPTION
Fix issue where capitalised user table names would cause foreign keys to have an incorrect name compared to what Sequelize Paper Trail is expecting