### PR TITLE
Fixes revisionId missing from RevisionChanges

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -318,7 +318,7 @@ exports.init = function (sequelize, optionsArg) {
             var d = RevisionChange.build({
               path: difference.path[0],
               document: JSON.stringify(difference),
-              //revisionId: data.id,
+              revisionId: revision.id,
               diff: JSON.stringify(o || n ? jsdiff.diffChars(o, n) : [])
             });
 


### PR DESCRIPTION
revisionId attribute was missing from RevisionChanges records as it was commented out during RevisionChange instance construction. This uncomments that line.