### PR TITLE
Option to disable auto association of revision model with user model

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,7 @@ var options = {
   enableCompression: false,
   enableMigration: false,
   enableStrictDiff: true,
+  enableAutoAssociation: true,
   continuationNamespace: 'current_user_request',
   continuationKey: 'userId'
 };
@@ -179,10 +180,11 @@ var options = {
 | [underscored] | Boolean | false | The [revisionModel] and [revisionChangeModel] have 'createdAt' and 'updatedAt' attributes, by default, setting this option to true changes it to 'created_at' and 'updated_at'. |
 | [underscoredAttributes] | Boolean | false | The [revisionModel] has a [defaultAttribute] 'documentId', and the [revisionChangeModel] has a  [defaultAttribute] 'revisionId, by default, setting this option to true changes it to 'document_id' and 'revision_id'. |
 | [defaultAttributes] | Object | { documentId: 'documentId', revisionId: 'revisionId' } |  |
-| [userModel] | String | | Name of the model that stores users in your. |
+| [userModel] | String | | Name of the model that stores users in your application. |
 | [enableCompression] | Boolean | false | Compresses the revision attribute in the [revisionModel] to only the diff instead of all model attributes. |
 | [enableMigration] | Boolean | false | Automatically adds the [revisionAttribute] via a migration to the models that have paper trails enabled. |
 | [enableStrictDiff] | Boolean | true | Reports integers and strings as different, e.g. `3.14` !== `'3.14'` |
+| [enableAutoAssociation] | Boolean | true | Automatically associate Revision model with userModel |
 | [continuationNamespace] | String | 'current_user_request' | Name of the name space used with the continuation-local-storage module. |
 | [continuationKey] | String | 'userId' | The continuation-local-storage key that contains the user id. |
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -105,6 +105,10 @@ exports.init = function (sequelize, optionsArg) {
     options.enableStrictDiff = true;
   }
 
+  if (options.enableAutoAssociation === undefined) {
+    options.enableAutoAssociation = true;
+  }
+
   if (!options.continuationNamespace) {
     options.continuationNamespace = 'current_user_request';
   }
@@ -391,9 +395,10 @@ exports.init = function (sequelize, optionsArg) {
       var Revision = sequelize.define(options.revisionModel, attributes, {
         underscored: options.underscored
       });
+
       Revision.associate = function associate(models) {
           Revision.belongsTo(sequelize.model(options.userModel));
-      }
+      };
 
       attributes = {
         path: {
@@ -440,9 +445,10 @@ exports.init = function (sequelize, optionsArg) {
       db[Revision.name] = Revision;
 
 
-      if (options.userModel) {
+      if (options.enableAutoAssociation && options.userModel) {
         Revision.belongsTo(sequelize.model(options.userModel));
       }
+
       return Revision;
     }
   };


### PR DESCRIPTION
Currently revision model tries to establish association with user
model during model creation. However, this does not work if the
user model is not defined at that moment. This would be the case if
we want to enable paper trail for the user model itself. In such
cases it is better to disable auto associating with user model,
and later associate explicityly using revision.associate function call.