### PR TITLE
Bugfix #42

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -312,7 +312,7 @@ exports.init = function (sequelize, optionsArg) {
         model: this.name,
         documentId: instance.id,
         document: JSON.stringify(currentVersion),
-        userId: ns && ns.get(options.continuationKey) || opt[options.continuationKey]
+        userId: ns && ns.get(options.continuationKey) || opt['userId']
       });
 
       revision[options.revisionAttribute] = instance.get(options.revisionAttribute);


### PR DESCRIPTION
Bugfix #42: `options.userId` name is fixed to not conflict with `continuationNamespace` options (reflect the documentation).