### PR TITLE
fix UUID assignment for underscored defaults

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -395,7 +395,7 @@ exports.init = function (sequelize, optionsArg) {
           type: Sequelize.UUID,
           defaultValue: Sequelize.UUIDV4
         };
-        attributes.documentId.type = Sequelize.UUID;
+        attributes[options.defaultAttributes.documentId].type = Sequelize.UUID;
       }
       // Revision model
       var Revision = sequelize.define(options.revisionModel, attributes, {


### PR DESCRIPTION
This update fixes the UUID datatype assignment for `document_id` when `UUID` is set to `true`.

It will also fix a bug that will arise if overriding field names are defined for the same use case.