### PR TITLE
Added a way to track deletions operations.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -10,8 +10,6 @@ var cls = require('continuation-local-storage');
 var failHard = false;
 
 exports.init = function (sequelize, optionsArg) {
-  // console.log(message); // eslint-disable-line
-
   // In case that options is being parsed as a readonly attribute.
   var options = _.cloneDeep(optionsArg);
   var defaultAttributes = {
@@ -57,7 +55,7 @@ exports.init = function (sequelize, optionsArg) {
   // fields we want to exclude from audit trails
   if (!options.exclude) {
     options.exclude = ["id", "createdAt", "updatedAt", "deletedAt", // if the model is paranoid
-    "created_at", "updated_at", "deleted_at", options.revisionAttribute];
+      "created_at", "updated_at", "deleted_at", options.revisionAttribute];
   }
 
   // model name for revision table
@@ -198,10 +196,12 @@ exports.init = function (sequelize, optionsArg) {
         });
       }
 
-      this.addHook("beforeCreate", beforeHook);
-      this.addHook("beforeUpdate", beforeHook);
-      this.addHook("afterCreate", afterHook);
-      this.addHook("afterUpdate", afterHook);
+      this.addHook("beforeCreate", createBeforeHook('create'));
+      this.addHook("beforeUpdate", createBeforeHook('update'));
+      this.addHook("beforeDestroy", createBeforeHook('destroy'));
+      this.addHook("afterCreate", createAfterHook('create'));
+      this.addHook("afterUpdate", createAfterHook('update'));
+      this.addHook("afterDestroy", createAfterHook('destroy'));
 
       // create association
       return this.hasMany(sequelize.models[options.revisionModel], {
@@ -214,147 +214,182 @@ exports.init = function (sequelize, optionsArg) {
     }
   });
 
-  var beforeHook = function beforeHook(instance, opt) {
-    if (debug) {
-      log('beforeHook called');
-      log('instance:');
-      log(instance);
-      log('opt:');
-      log(opt);
-    }
-
-    if (options.enableCompression) {
-      var previousVersion = {};
-      var currentVersion = {};
-
-      _.forEach(opt.defaultFields, function (a) {
-        console.log(a);
-		  const previousDataValuesOfA = instance._previousDataValues[a] === undefined ? null : instance._previousDataValues[a];
-		  previousVersion[a] = instance._previousDataValues[a]; previousVersion[a] = instance._previousDataValues[a];
-		  currentVersion[a] = instance.dataValues[a]; currentVersion[a] = instance.dataValues[a];
-      });
-    } else {
-      var previousVersion = instance._previousDataValues;
-      var currentVersion = instance.dataValues;
-    }
-    // Supported nested models.
-    previousVersion = _.omitBy(previousVersion, function (i) {return typeof i === 'object'});
-    currentVersion = _.omitBy(currentVersion, function (i) {return typeof i === 'object'});
-
-    // Disallow change of revision
-    instance.set(options.revisionAttribute, instance._previousDataValues[options.revisionAttribute]);
-
-    // Get diffs
-    var delta = helpers.calcDelta(previousVersion, currentVersion, options.exclude, options.enableStrictDiff);
-    var currentRevisionId = instance.get(options.revisionAttribute);
-    if (failHard && !currentRevisionId && opt.type === 'UPDATE') {
-      throw new Error('Revision Id was undefined');
-    }
-    if (debug) {
-      log('delta:');
-      log(delta);
-      log('revisionId', currentRevisionId);
-    }
-
-    if (delta && delta.length > 0) {
-      instance.set(options.revisionAttribute, (currentRevisionId || 0) + 1);
-
-      if (!instance.context) {
-        instance.context = {};
+  function createBeforeHook(operation) {
+    var beforeHook = function beforeHook(instance, opt) {
+      if (debug) {
+        log('beforeHook called');
+        log('instance:');
+        log(instance);
+        log('opt:');
+        log(opt);
       }
-      instance.context.delta = delta;
-    }
-    if (debug) {
-      log('end of beforeHook');
-    }
-  };
 
-  var afterHook = function afterHook(instance, opt) {
-    if (debug) {
-      log('afterHook called');
-      log('instance:', instance);
-      log('opt:', opt);
-      if (ns) {
-        log(`CLS ${options.continuationKey}:`, ns.get(options.continuationKey));
-      }
-    }
+      var destroyOperation = operation === 'destroy';
 
-    if (instance.context && instance.context.delta && instance.context.delta.length > 0) {
-      var Revision = sequelize.model(options.revisionModel);
-      if (options.enableRevisionChangeModel) {
-        var RevisionChange = sequelize.model(options.revisionChangeModel);
-      }
-      var delta = instance.context.delta;
-
-      if (options.enableCompression) {
+      if (!destroyOperation && options.enableCompression) {
         var previousVersion = {};
         var currentVersion = {};
 
         _.forEach(opt.defaultFields, function (a) {
+          const previousDataValuesOfA = instance._previousDataValues[a] === undefined ? null : instance._previousDataValues[a];
           previousVersion[a] = instance._previousDataValues[a];
+          previousVersion[a] = instance._previousDataValues[a];
+          currentVersion[a] = instance.dataValues[a];
           currentVersion[a] = instance.dataValues[a];
         });
       } else {
         var previousVersion = instance._previousDataValues;
         var currentVersion = instance.dataValues;
       }
-
       // Supported nested models.
-      previousVersion = _.omitBy(previousVersion, function (i) {return typeof i === 'object'});
-      currentVersion = _.omitBy(currentVersion, function (i) {return typeof i === 'object'});
+      previousVersion = _.omitBy(previousVersion, function (i) {
+        return typeof i === 'object'
+      });
+      currentVersion = _.omitBy(currentVersion, function (i) {
+        return typeof i === 'object'
+      });
 
-      if (failHard && !ns.get(options.continuationKey)) {
-        throw new Error('The CLS continuationKey ' + options.continuationKey + ' was not defined.');
+      // Disallow change of revision
+      instance.set(options.revisionAttribute, instance._previousDataValues[options.revisionAttribute]);
+
+      // Get diffs
+      var delta = helpers.calcDelta(previousVersion, currentVersion, options.exclude, options.enableStrictDiff);
+      var currentRevisionId = instance.get(options.revisionAttribute);
+      if (failHard && !currentRevisionId && opt.type === 'UPDATE') {
+        throw new Error('Revision Id was undefined');
+      }
+      if (debug) {
+        log('delta:');
+        log(delta);
+        log('revisionId', currentRevisionId);
       }
 
-      // Build revision
-      var revision = Revision.build({
-        model: this.name,
-        documentId: instance.id,
-        document: JSON.stringify(currentVersion),
-        userId: ns && ns.get(options.continuationKey) || opt['userId']
-      });
+      if (destroyOperation || delta && delta.length > 0) {
+        var revisionId = (currentRevisionId || 0) + 1;
+        instance.set(options.revisionAttribute, revisionId);
 
-      revision[options.revisionAttribute] = instance.get(options.revisionAttribute);
-
-      // Save revision
-      return revision.save({transaction: opt.transaction}).then(function (revision) {
-        // Loop diffs and create a revision-diff for each
-        if (options.enableRevisionChangeModel) {
-          _.forEach(delta, function (difference) {
-            var o = helpers.diffToString(difference.item ? difference.item.lhs : difference.lhs);
-            var n = helpers.diffToString(difference.item ? difference.item.rhs : difference.rhs);
-
-            var d = RevisionChange.build({
-              path: difference.path[0],
-              document: JSON.stringify(difference),
-              //revisionId: data.id,
-              diff: JSON.stringify(o || n ? jsdiff.diffChars(o, n) : [])
-            });
-
-            d.save({transaction: opt.transaction}).then(function (d) {
-              // Add diff to revision
-              revision['add' + helpers.capitalizeFirstLetter(options.revisionChangeModel)](d);
-
-              return null;
-            }).catch(function (err) {
-              log('RevisionChange save error');
-              log(err);
-              throw err;
-            });
-          });
+        if (!instance.context) {
+          instance.context = {};
         }
-        return null;
-      }).catch(function (err) {
-        log('Revision save error');
-        log(err);
-        throw err;
-      });
-    }
+        instance.context.delta = delta;
+      }
+      if (debug) {
+        log('end of beforeHook');
+      }
+    };
+    return beforeHook;
+  }
 
-    if (debug) {
-      log('end of afterHook');
-    }
+  function createAfterHook(operation) {
+    var afterHook = function afterHook(instance, opt) {
+      if (debug) {
+        log('afterHook called');
+        log('instance:', instance);
+        log('opt:', opt);
+        if (ns) {
+          log(`CLS ${options.continuationKey}:`, ns.get(options.continuationKey));
+        }
+      }
+
+      var destroyOperation = operation === 'destroy';
+
+      if (instance.context && (instance.context.delta && instance.context.delta.length > 0 || destroyOperation)) {
+        var Revision = sequelize.model(options.revisionModel);
+        if (options.enableRevisionChangeModel) {
+          var RevisionChange = sequelize.model(options.revisionChangeModel);
+        }
+        var delta = instance.context.delta;
+
+        if (!destroyOperation && options.enableCompression) {
+          var previousVersion = {};
+          var currentVersion = {};
+
+          _.forEach(opt.defaultFields, function (a) {
+            previousVersion[a] = instance._previousDataValues[a];
+            currentVersion[a] = instance.dataValues[a];
+          });
+        } else {
+          var previousVersion = instance._previousDataValues;
+          var currentVersion = instance.dataValues;
+        }
+
+        // Supported nested models.
+        previousVersion = _.omitBy(previousVersion, function (i) {
+          return typeof i === 'object'
+        });
+        currentVersion = _.omitBy(currentVersion, function (i) {
+          return typeof i === 'object'
+        });
+
+        if (failHard && !ns.get(options.continuationKey)) {
+          throw new Error('The CLS continuationKey ' + options.continuationKey + ' was not defined.');
+        }
+
+        var document = currentVersion;
+        ;
+        if (options.mysql) {
+          document = JSON.stringify(document);
+        }
+
+        // Build revision
+        var revision = Revision.build({
+          model: this.name,
+          documentId: instance.id,
+          document: document,
+          userId: ns && ns.get(options.continuationKey) || opt['userId'],
+          operation: operation
+        });
+
+        revision[options.revisionAttribute] = instance.get(options.revisionAttribute);
+
+        // Save revision
+        return revision.save({transaction: opt.transaction}).then(function (revision) {
+          // Loop diffs and create a revision-diff for each
+          if (options.enableRevisionChangeModel) {
+            _.forEach(delta, function (difference) {
+              var o = helpers.diffToString(difference.item ? difference.item.lhs : difference.lhs);
+              var n = helpers.diffToString(difference.item ? difference.item.rhs : difference.rhs);
+
+              var document = difference;
+              var diff = o || n ? jsdiff.diffChars(o, n) : []
+
+              if (options.mysql) {
+                document = JSON.stringify(document);
+                diff = JSON.stringify(diff)
+              }
+
+              var d = RevisionChange.build({
+                path: difference.path[0],
+                document: document,
+                //revisionId: data.id,
+                diff: diff
+              });
+
+              d.save({transaction: opt.transaction}).then(function (d) {
+                // Add diff to revision
+                revision['add' + helpers.capitalizeFirstLetter(options.revisionChangeModel)](d);
+
+                return null;
+              }).catch(function (err) {
+                log('RevisionChange save error');
+                log(err);
+                throw err;
+              });
+            });
+          }
+          return null;
+        }).catch(function (err) {
+          log('Revision save error');
+          log(err);
+          throw err;
+        });
+      }
+
+      if (debug) {
+        log('end of afterHook');
+      }
+    };
+    return afterHook;
   };
 
   return {
@@ -368,7 +403,8 @@ exports.init = function (sequelize, optionsArg) {
         document: {
           type: Sequelize.JSON,
           allowNull: false
-        }
+        },
+        operation: Sequelize.STRING(7)
       };
 
       if (options.mysql) {
@@ -402,7 +438,7 @@ exports.init = function (sequelize, optionsArg) {
         underscored: options.underscored
       });
       Revision.associate = function associate(models) {
-          Revision.belongsTo(sequelize.model(options.userModel));
+        Revision.belongsTo(sequelize.model(options.userModel));
       }
 
       attributes = {


### PR DESCRIPTION
Solves the issue #54.

When a record is destroyed, a revision with all attributes is stored, independent of the attribute `enableCompression` is enabled or not.

In complement, a new attribute `operation` was created in revison model, that identify what triggered operation was responsible to the new revision. The possible values are: `create`, `update` and `destroy`.