### PR TITLE
Removing unnecessary obligatory parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ then adding Sequelize Paper Trail is as easy as:
 
 ```javascript
 var PaperTrail = require('sequelize-paper-trail').init(sequelize, options);
-PaperTrail.defineModels({});
+PaperTrail.defineModels();
 ```
 
 which loads the Paper Trail library, and the `defineModels()` method sets up a `Revisions` and `RevisionHistory` table.

--- a/lib/index.js
+++ b/lib/index.js
@@ -441,7 +441,7 @@ exports.init = function (sequelize, optionsArg) {
       });
       Revision.associate = function associate(models) {
         Revision.belongsTo(sequelize.model(options.userModel));
-      }
+      };
 
       attributes = {
         path: {
@@ -482,11 +482,10 @@ exports.init = function (sequelize, optionsArg) {
         });
 
         RevisionChange.belongsTo(Revision);
-        db[RevisionChange.name] = RevisionChange;
+        if (db) db[RevisionChange.name] = RevisionChange;
       }
 
-      db[Revision.name] = Revision;
-
+      if (db) db[Revision.name] = Revision;
 
       if (options.userModel) {
         Revision.belongsTo(sequelize.model(options.userModel));


### PR DESCRIPTION
Removing the obligatory object instance of `PaperTrail.defineModels`. I kept it just to not broke some existing implementation. The `Revison` and `RevisionChange` entities can be easily caughted by sequelize instance, for example:

```javascript
sequelize.models['revision']
sequelize.models['revisionChange']
```