### PR TITLE
Change how previous and current versions are filtered

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -209,16 +209,10 @@ exports.init = (sequelize, optionsArg) => {
 				currentVersion = instance.dataValues;
 			}
 			// Supported nested models.
-			previousVersion = _.omitBy(
-				previousVersion,
-				i => i != null && typeof i === 'object' && !(i instanceof Date),
-			);
+			previousVersion = _.pick(previousVersion, Object.keys(instance.rawAttributes));
 			previousVersion = _.omit(previousVersion, options.exclude);
 
-			currentVersion = _.omitBy(
-				currentVersion,
-				i => i != null && typeof i === 'object' && !(i instanceof Date),
-			);
+			currentVersion = _.pick(currentVersion, Object.keys(instance.rawAttributes));
 			currentVersion = _.omit(currentVersion, options.exclude);
 
 			// Disallow change of revision
@@ -349,22 +343,10 @@ exports.init = (sequelize, optionsArg) => {
 				}
 
 				// Supported nested models.
-				previousVersion = _.omitBy(
-					previousVersion,
-					i =>
-						i != null &&
-						typeof i === 'object' &&
-						!(i instanceof Date),
-				);
+				previousVersion = _.pick(previousVersion, Object.keys(instance.rawAttributes));
 				previousVersion = _.omit(previousVersion, options.exclude);
 
-				currentVersion = _.omitBy(
-					currentVersion,
-					i =>
-						i != null &&
-						typeof i === 'object' &&
-						!(i instanceof Date),
-				);
+				currentVersion = _.pick(currentVersion, Object.keys(instance.rawAttributes));
 				currentVersion = _.omit(currentVersion, options.exclude);
 
 				if (failHard && ns && !ns.get(options.continuationKey)) {


### PR DESCRIPTION
Filters `previousVersion` and `currentVersion` by Sequelize's `rawAttributes`. The purpose is to allow JSONB objects to be saved in the document.

I am not 100% sure what the previous omitBy usage was for though.