### PR TITLE
JSON field does not work anymore in MySQL 5.7+

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,7 +190,8 @@ const options = {
   continuationKey: 'userId',
   belongsToUserOptions: undefined,
   metaDataFields: undefined,
-  metaDataContinuationKey: 'metaData'
+  metaDataContinuationKey: 'metaData',
+  documentFieldType: 'postgres'
 };
 ```
 
@@ -218,6 +219,7 @@ const options = {
 | [belongsToUserOptions]      | Object  | undefined                                                                                                            | The options used for belongsTo between userModel and Revision model                                                                                                                                                    |
 | [metaDataFields]            | Object  | undefined                                                                                                            | The keys that will be provided in the meta data object. { key: isRequired (boolean)} format. Can be used to privovide additional fields - other associations, dates, etc to the Revision model                         |
 | [metaDataContinuationKey]   | String  | 'metaData'                                                                                                           | The continuation-local-storage key that contains the meta data object, from where the metaDataFields are extracted.                                                                                                    |
+| [documentFieldType]         | String  | ['legacy', 'postgres', 'mysql']                                                                                      | Changes the type of field 'document' what will be created. 'legacy' produces a `TEXT`, 'postgres' a `JSONB` and 'mysql' a `JSON` field.                                                                                |
 
 ## Limitations
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -608,6 +608,8 @@ exports.init = (sequelize, optionsArg) => {
 
 			if (options.documentFieldType === 'legacy') {
 				attributes.document.type = Sequelize.TEXT('MEDIUMTEXT');
+			} else if (options.documentFieldType === 'mysql') {
+				attributes.document.type = Sequelize.JSON;
 			}
 
 			attributes[options.defaultAttributes.documentId] = {
@@ -674,6 +676,9 @@ exports.init = (sequelize, optionsArg) => {
 				if (options.documentFieldType === 'legacy') {
 					attributes.document.type = Sequelize.TEXT('MEDIUMTEXT');
 					attributes.diff.type = Sequelize.TEXT('MEDIUMTEXT');
+				} else if (options.documentFieldType === 'mysql') {
+					attributes.document.type = Sequelize.JSON;
+					attributes.diff.type = Sequelize.JSON;
 				}
 
 				if (options.UUID) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -44,7 +44,7 @@ exports.init = (sequelize, optionsArg) => {
 		continuationKey: 'userId',
 		metaDataFields: null,
 		metaDataContinuationKey: 'metaData',
-		mysql: false,
+		documentFieldType: 'postgres',
 	};
 
 	let ns = null;
@@ -57,6 +57,11 @@ exports.init = (sequelize, optionsArg) => {
 
 	if (optsArg.underscoredAttributes) {
 		helpers.toUnderscored(defaultOptions.defaultAttributes);
+	}
+
+	// keep the compatibility with old project
+	if (optsArg.mysql && !optsArg.documentFieldType) {
+		optsArg.documentFieldType = 'legacy';
 	}
 
 	const options = _.defaults(optsArg, defaultOptions);
@@ -375,7 +380,7 @@ exports.init = (sequelize, optionsArg) => {
 
 				let document = currentVersion;
 
-				if (options.mysql) {
+				if (options.documentFieldType === 'legacy') {
 					document = JSON.stringify(document);
 				}
 
@@ -448,7 +453,7 @@ exports.init = (sequelize, optionsArg) => {
 								document = difference;
 								let diff = o || n ? jsdiff.diffChars(o, n) : [];
 
-								if (options.mysql) {
+								if (options.documentFieldType === 'legacy') {
 									document = JSON.stringify(document);
 									diff = JSON.stringify(diff);
 								}
@@ -601,7 +606,7 @@ exports.init = (sequelize, optionsArg) => {
 				operation: Sequelize.STRING(7),
 			};
 
-			if (options.mysql) {
+			if (options.documentFieldType === 'legacy') {
 				attributes.document.type = Sequelize.TEXT('MEDIUMTEXT');
 			}
 
@@ -666,7 +671,7 @@ exports.init = (sequelize, optionsArg) => {
 					},
 				};
 
-				if (options.mysql) {
+				if (options.documentFieldType === 'legacy') {
 					attributes.document.type = Sequelize.TEXT('MEDIUMTEXT');
 					attributes.diff.type = Sequelize.TEXT('MEDIUMTEXT');
 				}


### PR DESCRIPTION
Solves the issue #91 

Undocumented option `mysql` was replaced by `documentFieldType`. The `mysql` still supported if `documentFieldType` it is not present.